### PR TITLE
Update Equipment autopickup to use capitalized subtype

### DIFF
--- a/gammafunk.rc
+++ b/gammafunk.rc
@@ -717,8 +717,8 @@ local function pickup_equipment(it, name)
 
   local class = it.class(true)
   if class == "armour" then
-    local good_slots = {cloak="Cloak", helmet="Helmet",
-                        gloves="Gloves", boots="Boots"}
+    local good_slots = {Cloak="Cloak", Helmet="Helmet",
+                        Gloves="Gloves", Boots="Boots"}
     st, _ = it.subtype()
 
     -- Autopickup found aux armour if 1) we don't have any or 2) it's artefact,

--- a/gammafunk_base.rc
+++ b/gammafunk_base.rc
@@ -717,8 +717,8 @@ local function pickup_equipment(it, name)
 
   local class = it.class(true)
   if class == "armour" then
-    local good_slots = {cloak="Cloak", helmet="Helmet",
-                        gloves="Gloves", boots="Boots"}
+    local good_slots = {Cloak="Cloak", Helmet="Helmet",
+                        Gloves="Gloves", Boots="Boots"}
     st, _ = it.subtype()
 
     -- Autopickup found aux armour if 1) we don't have any or 2) it's artefact,


### PR DESCRIPTION
Item subtypes need to be capitalized after https://github.com/crawl/crawl/commit/2dbd7c1ffd74f34fc6c2de16f9470e8d4fb2abf5 